### PR TITLE
Cleanup of already available tools for macOS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Install macOS deps
+      if: ${{ startsWith(runner.os, 'macOS') }}
+      shell: bash
+      run: |
+        brew install doxygen --formula
+
     - name: Install Linux deps
       if: ${{ startsWith(runner.os, 'Linux') }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -28,18 +28,10 @@ inputs:
   target:
     description: 'Product to be build e.g. buildmgr'
     required: true
+
 runs:
   using: "composite"
   steps:
-    - name: Install macOS deps
-      if: ${{ startsWith(runner.os, 'macOS') }}
-      shell: bash
-      run: |
-        brew install \
-          ninja \
-          doxygen \
-          swig
-
     - name: Install Linux deps
       if: ${{ startsWith(runner.os, 'Linux') }}
       shell: bash


### PR DESCRIPTION
Fix: Resolved warning in macOS builds regarding the availability of ninja and swig on macOS

```
build (macos-13, darwin, amd64, publicRepo, svdconv)
ninja 1.12.1 is already installed and up-to-date. To reinstall 1.12.1, run: brew reinstall ninja

build (macos-13, darwin, amd64, publicRepo, svdconv)
Treating doxygen as a formula. For the cask, use homebrew/cask/doxygen or specify the `--cask` flag. To silence this message, use the `--formula` flag.

build (macos-14, darwin, arm64, publicRepo, svdconv)
ninja 1.12.1 is already installed and up-to-date. To reinstall 1.12.1, run: brew reinstall ninja

build (macos-14, darwin, arm64, publicRepo, svdconv)
Treating doxygen as a formula. For the cask, use homebrew/cask/doxygen or specify the `--cask` flag. To silence this message, use the `--formula` flag.

test (macos-14, darwin, arm64, publicRepo, svdconv)
swig 4.3.1 is already installed and up-to-date. To reinstall 4.3.1, run: brew reinstall swig
```










