### PR TITLE
Improve macOS deps installation logic

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "doxygen"
+brew "swig"

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
       if: ${{ startsWith(runner.os, 'macOS') }}
       shell: bash
       run: |
-        brew bundle --file="${{ github.action_path }}/Brewfile" --no-lock
+        brew bundle --file="${{ github.action_path }}/Brewfile"
         doxygen --version
         swig -version
 

--- a/action.yml
+++ b/action.yml
@@ -36,14 +36,7 @@ runs:
       if: ${{ startsWith(runner.os, 'macOS') }}
       shell: bash
       run: |
-        if ! brew list --formula | grep -q '^doxygen$'; then
-          brew install doxygen
-        fi
-    
-        if ! brew list --formula | grep -q '^swig$'; then
-          brew install swig
-        fi
-    
+        brew bundle --file="${{ github.action_path }}/Brewfile" --no-lock
         doxygen --version
         swig -version
 

--- a/action.yml
+++ b/action.yml
@@ -32,12 +32,20 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install macOS deps
+    - name: Install macOS deps (only if missing)
       if: ${{ startsWith(runner.os, 'macOS') }}
       shell: bash
       run: |
-        brew install doxygen --formula
-        brew install swig
+        if ! brew list --formula | grep -q '^doxygen$'; then
+          brew install doxygen
+        fi
+    
+        if ! brew list --formula | grep -q '^swig$'; then
+          brew install swig
+        fi
+    
+        doxygen --version
+        swig -version
 
     - name: Install Linux deps
       if: ${{ startsWith(runner.os, 'Linux') }}

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
       if: ${{ startsWith(runner.os, 'macOS') }}
       shell: bash
       run: |
-        brew bundle --file="${{ github.action_path }}/Brewfile"
+        brew bundle install --file="${{ github.action_path }}/Brewfile" --no-upgrade
         doxygen --version
         swig -version
 


### PR DESCRIPTION
Update macOS dependency installation to check for existing packages before installing to fix:

```
Warning: doxygen 1.16.1 is already installed and up-to-date.
Warning: swig 4.4.1 is already installed and up-to-date.
```